### PR TITLE
Speed and reliablity improvements

### DIFF
--- a/mcumgr-ble/build.gradle
+++ b/mcumgr-ble/build.gradle
@@ -20,7 +20,7 @@ android {
 
 dependencies {
     // Import the BLE Library
-    api 'no.nordicsemi.android:ble:2.0.0'
+    api 'no.nordicsemi.android:ble:2.0.3'
 
     // Logging
     implementation 'org.slf4j:slf4j-api:1.7.25'

--- a/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
+++ b/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/McuMgrBleTransport.java
@@ -27,6 +27,7 @@ import io.runtime.mcumgr.McuMgrTransport;
 import io.runtime.mcumgr.exception.InsufficientMtuException;
 import io.runtime.mcumgr.exception.McuMgrErrorException;
 import io.runtime.mcumgr.exception.McuMgrException;
+import io.runtime.mcumgr.exception.McuMgrTimeoutException;
 import io.runtime.mcumgr.response.McuMgrResponse;
 import io.runtime.mcumgr.ble.callback.SmpDataCallback;
 import io.runtime.mcumgr.ble.callback.SmpMerger;
@@ -181,6 +182,9 @@ public class McuMgrBleTransport extends BleManager<BleManagerCallbacks> implemen
                     // a second time and to a different device than the one that's already
                     // connected. This may not happen here.
                     throw new McuMgrException("Other device already connected");
+                case FailCallback.REASON_TIMEOUT:
+                    // Called after receiving error 133 after 30 seconds.
+                    throw new McuMgrTimeoutException();
                 default:
                     // Other errors are currently never thrown for the connect request.
                     throw new McuMgrException("Unknown error");
@@ -315,6 +319,10 @@ public class McuMgrBleTransport extends BleManager<BleManagerCallbacks> implemen
                         // a second time and to a different device than the one that's already
                         // connected. This may not happen here.
                         callback.onError(new McuMgrException("Other device already connected"));
+                        break;
+                    case REASON_TIMEOUT:
+                        // Called after receiving error 133 after 30 seconds.
+                        callback.onError(new McuMgrTimeoutException());
                         break;
                     case REASON_BLUETOOTH_DISABLED:
                         callback.onError(new McuMgrException("Bluetooth adapter disabled"));

--- a/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/callback/SmpDataCallback.java
+++ b/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/callback/SmpDataCallback.java
@@ -9,8 +9,6 @@ package io.runtime.mcumgr.ble.callback;
 import android.bluetooth.BluetoothDevice;
 import android.support.annotation.NonNull;
 
-import java.io.IOException;
-
 import io.runtime.mcumgr.McuMgrScheme;
 import io.runtime.mcumgr.response.McuMgrResponse;
 import no.nordicsemi.android.ble.callback.profile.ProfileDataCallback;
@@ -29,7 +27,7 @@ public abstract class SmpDataCallback<T extends McuMgrResponse>
         try {
             T response = McuMgrResponse.buildResponse(McuMgrScheme.BLE, data.getValue(), responseType);
             onResponseReceived(device, response);
-        } catch (IOException e) {
+        } catch (final Exception e) {
             onInvalidDataReceived(device, data);
         }
     }

--- a/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/callback/SmpMerger.java
+++ b/mcumgr-ble/src/main/java/io/runtime/mcumgr/ble/callback/SmpMerger.java
@@ -7,6 +7,7 @@
 package io.runtime.mcumgr.ble.callback;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import java.io.IOException;
 
@@ -19,13 +20,18 @@ public class SmpMerger implements DataMerger {
     private Integer mExpectedLength;
 
     @Override
-    public boolean merge(@NonNull final DataStream output, @NonNull final byte[] lastPacket, final int index) {
+    public boolean merge(@NonNull final DataStream output, @Nullable final byte[] lastPacket, final int index) {
         // Add the new packet to the output stream
         output.write(lastPacket);
 
         // If it's a first or a single packet of this message, try to read the expected length
         if (index == 0) {
             try {
+                // This should never happen, but let's not crash if it did
+                if (lastPacket == null) {
+                    return true;
+                }
+                // Read the expected length from the header
                 mExpectedLength = McuMgrResponse.getExpectedLength(McuMgrScheme.BLE, lastPacket);
             } catch (final IOException e) {
                 return true;

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradeManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradeManager.java
@@ -19,6 +19,7 @@ import java.util.Arrays;
 import java.util.concurrent.Executor;
 
 import io.runtime.mcumgr.McuMgrCallback;
+import io.runtime.mcumgr.McuMgrScheme;
 import io.runtime.mcumgr.McuMgrTransport;
 import io.runtime.mcumgr.exception.McuMgrErrorException;
 import io.runtime.mcumgr.exception.McuMgrException;
@@ -148,6 +149,35 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
         mImageManager = new ImageManager(transport);
         mDefaultManager = new DefaultManager(transport);
         mCallback = callback;
+    }
+
+    /**
+     * Get the transporter.
+     *
+     * @return Transporter for this new manager instance.
+     */
+    @NotNull
+    public McuMgrTransport getTransporter() {
+        return mImageManager.getTransporter();
+    }
+
+    /**
+     * Get the transporter's scheme.
+     *
+     * @return The transporter's scheme.
+     */
+    @NotNull
+    public McuMgrScheme getScheme() {
+        return mImageManager.getScheme();
+    }
+
+    /**
+     * Returns the upload MTU. MTU must be between 20 and 1024.
+     *
+     * @return The MTY.
+     */
+    public synchronized int getMtu() {
+        return mImageManager.getMtu();
     }
 
     /**

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradeManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/dfu/FirmwareUpgradeManager.java
@@ -363,6 +363,11 @@ public class FirmwareUpgradeManager implements FirmwareUpgradeController {
                     }
 
                     McuMgrImageStateResponse.ImageSlot[] images = response.images;
+                    if (images == null) {
+                        LOG.error("Missing images information: {}", response.toString());
+                        fail(new McuMgrException("Missing images information"));
+                        return;
+                    }
 
                     // Check if the new firmware is different than the active one.
                     if (images.length > 0 && Arrays.equals(mHash, images[0].hash)) {

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/exception/InsufficientMtuException.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/exception/InsufficientMtuException.java
@@ -14,6 +14,7 @@ import io.runtime.mcumgr.dfu.FirmwareUpgradeManager;
  * MTU. This is used in practice by the {@link FirmwareUpgradeManager} to resize it's packets to
  * fit within the transporter's MTU.
  */
+@SuppressWarnings("unused")
 public class InsufficientMtuException extends McuMgrException {
     private int mMtu;
     private int mDataLength;

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/exception/McuMgrErrorException.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/exception/McuMgrErrorException.java
@@ -17,6 +17,7 @@ import io.runtime.mcumgr.response.McuMgrResponse;
  * practice by {@link FirmwareUpgradeManager} to send a failure callback with the
  * {@link McuMgrErrorCode} that caused the failure.
  */
+@SuppressWarnings("unused")
 public class McuMgrErrorException extends McuMgrException {
     @NotNull
     private McuMgrErrorCode mCode;

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/exception/McuMgrTimeoutException.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/exception/McuMgrTimeoutException.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2017-2018 Runtime Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package io.runtime.mcumgr.exception;
+
+import io.runtime.mcumgr.McuMgrErrorCode;
+import io.runtime.mcumgr.dfu.FirmwareUpgradeManager;
+
+/**
+ * Used to convey errors caused by an {@link McuMgrErrorCode} within a response. This is used in
+ * practice by {@link FirmwareUpgradeManager} to send a failure callback with the
+ * {@link McuMgrErrorCode} that caused the failure.
+ */
+@SuppressWarnings("unused")
+public class McuMgrTimeoutException extends McuMgrException {
+}

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/McuMgrResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/McuMgrResponse.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,8 +82,8 @@ public class McuMgrResponse {
             return CBOR.toString(mPayload);
         } catch (IOException e) {
             LOG.error("Failed to parse response", e);
+            return "Failed to parse response";
         }
-        return null;
     }
 
     /**
@@ -90,6 +91,7 @@ public class McuMgrResponse {
      *
      * @return The McuMgrHeader.
      */
+    @NotNull
     public McuMgrHeader getHeader() {
         return mHeader;
     }
@@ -189,8 +191,9 @@ public class McuMgrResponse {
      * @param payload McuMgr CBOR payload.
      * @param rc      the return code.
      */
-    void initFields(McuMgrScheme scheme, byte[] bytes, McuMgrHeader header, byte[] payload,
-                    McuMgrErrorCode rc) {
+    void initFields(@NotNull McuMgrScheme scheme, @NotNull byte[] bytes,
+                    @NotNull McuMgrHeader header, @NotNull byte[] payload,
+                    @NotNull McuMgrErrorCode rc) {
         mScheme = scheme;
         mBytes = bytes;
         mHeader = header;
@@ -209,8 +212,10 @@ public class McuMgrResponse {
      * @throws IOException              Error parsing response.
      * @throws IllegalArgumentException If the scheme is CoAP.
      */
-    public static <T extends McuMgrResponse> T buildResponse(McuMgrScheme scheme, byte[] bytes,
-                                                             Class<T> type) throws IOException {
+    public static <T extends McuMgrResponse> T buildResponse(@NotNull McuMgrScheme scheme,
+                                                             @NotNull byte[] bytes,
+                                                             @NotNull Class<T> type)
+            throws IOException {
         if (scheme.isCoap()) {
             throw new IllegalArgumentException("Cannot use this method with a CoAP scheme");
         }
@@ -243,10 +248,13 @@ public class McuMgrResponse {
      * @throws IOException         if parsing the payload into the object (type T) failed
      * @throws McuMgrCoapException if the CoAP code class indicates a CoAP error response
      */
-    public static <T extends McuMgrResponse> T buildCoapResponse(McuMgrScheme scheme, byte[] bytes,
-                                                                 byte[] header, byte[] payload,
+    public static <T extends McuMgrResponse> T buildCoapResponse(@NotNull McuMgrScheme scheme,
+                                                                 @NotNull byte[] bytes,
+                                                                 @NotNull byte[] header,
+                                                                 @NotNull byte[] payload,
                                                                  int codeClass, int codeDetail,
-                                                                 Class<T> type) throws IOException, McuMgrCoapException {
+                                                                 Class<T> type)
+            throws IOException, McuMgrCoapException {
         // If the code class indicates a CoAP error response, throw a McuMgrCoapException
         if (codeClass == 4 || codeClass == 5) {
             LOG.error("Received CoAP Error response, throwing McuMgrCoapException");
@@ -261,7 +269,8 @@ public class McuMgrResponse {
         return response;
     }
 
-    public static boolean requiresDefragmentation(McuMgrScheme scheme, byte[] bytes) throws IOException {
+    public static boolean requiresDefragmentation(@NotNull McuMgrScheme scheme, @NotNull byte[] bytes)
+            throws IOException {
         if (scheme.isCoap()) {
             throw new UnsupportedOperationException("Method not implemented for CoAP");
         } else {
@@ -270,7 +279,8 @@ public class McuMgrResponse {
         }
     }
 
-    public static int getExpectedLength(McuMgrScheme scheme, byte[] bytes) throws IOException {
+    public static int getExpectedLength(@NotNull McuMgrScheme scheme, @NotNull byte[] bytes)
+            throws IOException {
         if (scheme.isCoap()) {
             throw new UnsupportedOperationException("Method not implemented for CoAP");
         } else {

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/FilesDownloadViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/FilesDownloadViewModel.java
@@ -14,10 +14,13 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import io.runtime.mcumgr.McuMgrErrorCode;
+import io.runtime.mcumgr.McuMgrTransport;
+import io.runtime.mcumgr.ble.McuMgrBleTransport;
 import io.runtime.mcumgr.exception.McuMgrErrorException;
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.managers.FsManager;
 import io.runtime.mcumgr.sample.viewmodel.SingleLiveEvent;
+import no.nordicsemi.android.ble.ConnectionPriorityRequest;
 
 @SuppressWarnings("unused")
 public class FilesDownloadViewModel extends McuMgrViewModel
@@ -58,6 +61,10 @@ public class FilesDownloadViewModel extends McuMgrViewModel
 
 	public void download(final String path) {
 		setBusy();
+		final McuMgrTransport transport = mManager.getTransporter();
+		if (transport instanceof McuMgrBleTransport) {
+			((McuMgrBleTransport) transport).requestConnPriority(ConnectionPriorityRequest.CONNECTION_PRIORITY_HIGH);
+		}
 		mManager.download(path, this);
 	}
 

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/FilesUploadViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/FilesUploadViewModel.java
@@ -13,9 +13,12 @@ import android.support.annotation.NonNull;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import io.runtime.mcumgr.McuMgrTransport;
+import io.runtime.mcumgr.ble.McuMgrBleTransport;
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.managers.FsManager;
 import io.runtime.mcumgr.sample.viewmodel.SingleLiveEvent;
+import no.nordicsemi.android.ble.ConnectionPriorityRequest;
 
 public class FilesUploadViewModel extends McuMgrViewModel implements FsManager.FileUploadCallback {
 	public enum State {
@@ -75,6 +78,10 @@ public class FilesUploadViewModel extends McuMgrViewModel implements FsManager.F
 	public void upload(final String path, final byte[] data) {
 		setBusy();
 		mStateLiveData.setValue(State.UPLOADING);
+		final McuMgrTransport transport = mManager.getTransporter();
+		if (transport instanceof McuMgrBleTransport) {
+			((McuMgrBleTransport) transport).requestConnPriority(ConnectionPriorityRequest.CONNECTION_PRIORITY_HIGH);
+		}
 		mManager.upload(path, data, this);
 	}
 

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
@@ -13,11 +13,14 @@ import android.support.annotation.NonNull;
 import javax.inject.Inject;
 import javax.inject.Named;
 
+import io.runtime.mcumgr.McuMgrTransport;
+import io.runtime.mcumgr.ble.McuMgrBleTransport;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeCallback;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeController;
 import io.runtime.mcumgr.dfu.FirmwareUpgradeManager;
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.sample.viewmodel.SingleLiveEvent;
+import no.nordicsemi.android.ble.ConnectionPriorityRequest;
 
 public class ImageUpgradeViewModel extends McuMgrViewModel implements FirmwareUpgradeCallback {
 	public enum State {
@@ -82,6 +85,10 @@ public class ImageUpgradeViewModel extends McuMgrViewModel implements FirmwareUp
 
 	public void upgrade(@NonNull final byte[] data, @NonNull final FirmwareUpgradeManager.Mode mode) {
 		try {
+			final McuMgrTransport transport = mManager.getTransporter();
+			if (transport instanceof McuMgrBleTransport) {
+				((McuMgrBleTransport) transport).requestConnPriority(ConnectionPriorityRequest.CONNECTION_PRIORITY_HIGH);
+			}
 			mManager.setMode(mode);
 			mManager.start(data);
 		} catch (final McuMgrException e) {

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUploadViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUploadViewModel.java
@@ -16,11 +16,14 @@ import javax.inject.Inject;
 import javax.inject.Named;
 
 import io.runtime.mcumgr.McuMgrCallback;
+import io.runtime.mcumgr.McuMgrTransport;
+import io.runtime.mcumgr.ble.McuMgrBleTransport;
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.image.McuMgrImage;
 import io.runtime.mcumgr.managers.ImageManager;
 import io.runtime.mcumgr.response.img.McuMgrImageStateResponse;
 import io.runtime.mcumgr.sample.viewmodel.SingleLiveEvent;
+import no.nordicsemi.android.ble.ConnectionPriorityRequest;
 
 public class ImageUploadViewModel extends McuMgrViewModel implements ImageManager.ImageUploadCallback {
 	public enum State {
@@ -92,6 +95,10 @@ public class ImageUploadViewModel extends McuMgrViewModel implements ImageManage
 			return;
 		}
 
+		final McuMgrTransport transport = mManager.getTransporter();
+		if (transport instanceof McuMgrBleTransport) {
+			((McuMgrBleTransport) transport).requestConnPriority(ConnectionPriorityRequest.CONNECTION_PRIORITY_HIGH);
+		}
 		mManager.list(new McuMgrCallback<McuMgrImageStateResponse>() {
 			@Override
 			public void onResponse(@NonNull final McuMgrImageStateResponse response) {


### PR DESCRIPTION
This PR, although not compatible with 2 other pending PRs, adds some minor improvements:
1. Adds a method to `McuMgrBleTransport` to request connection priority. This may improve speed. I didn't request the priority in `initialize()` as this may not be required.
2. Adds 2 retry attempts to to connect to the device after it was rebooted. On nRF85840 the swap operation takes ~30 seconds and some phones may not pick up the adv interval in remaining time (if there is any). Issue found on Samsung Note 8 when adv interval is 1 second.
3. Null checks