### PR TITLE
Improved waiting for fw swapping.

### DIFF
--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/ImageUpgradeViewModel.java
@@ -58,6 +58,7 @@ public class ImageUpgradeViewModel extends McuMgrViewModel implements FirmwareUp
 						  @Named("busy") final MutableLiveData<Boolean> state) {
 		super(state);
 		mManager = manager;
+		mManager.setEstimatedSwapTime(20000);
 		mManager.setFirmwareUpgradeCallback(this);
 		mStateLiveData.setValue(State.IDLE);
 		mProgressLiveData.setValue(0);
@@ -116,7 +117,6 @@ public class ImageUpgradeViewModel extends McuMgrViewModel implements FirmwareUp
 	public void cancel() {
 		mManager.cancel();
 	}
-
 
 	@Override
 	public void onUpgradeStarted(final FirmwareUpgradeController controller) {


### PR DESCRIPTION
As @bgiori pointed out, the supervision timeout may be 20 sec. There is no need to wait this time again, assuming estimated swapping time > 20 sec and immediate reset after Reset response was received.
This PR deducts the time passed since receiving reset command response until the connection state change to disconnected.