### PR TITLE
use long instead of int for log index

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.7.0
+VERSION_NAME=0.7.0-SNAPSHOT
 GROUP=io.runtime.mcumgr
 
 POM_DESCRIPTION=A mobile management library for devices running Apache Mynewt and Zephyr (DFU, logs, stats, config, etc.)

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/LogManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/LogManager.java
@@ -111,7 +111,7 @@ public class LogManager extends McuManager {
      * @throws McuMgrException Transport error. See cause.
      */
     @NotNull
-    public McuMgrLogResponse show(@Nullable String logName, @Nullable Integer minIndex,
+    public McuMgrLogResponse show(@Nullable String logName, @Nullable Long minIndex,
                                   @Nullable Date minTimestamp)
             throws McuMgrException {
         HashMap<String, Object> payloadMap = new HashMap<>();
@@ -293,7 +293,7 @@ public class LogManager extends McuManager {
                 break;
             }
             // Get the index of the last entry in the list and set the LogState nextIndex
-            int nextIndex = log.entries[log.entries.length - 1].index + 1;
+            long nextIndex = log.entries[log.entries.length - 1].index + 1;
             state.setNextIndex(nextIndex);
             // Add entries to the list and set the next index
             state.getEntries().addAll(Arrays.asList(log.entries));
@@ -341,7 +341,7 @@ public class LogManager extends McuManager {
         /**
          * The next index to use to get new logs.
          */
-        private int mNextIndex = 0;
+        private long mNextIndex = 0;
 
         /**
          * The list of entries pulled from the log.
@@ -352,7 +352,7 @@ public class LogManager extends McuManager {
             this(name, 0);
         }
 
-        public State(String name, int nextIndex) {
+        public State(String name, long nextIndex) {
             mName = name;
             mNextIndex = nextIndex;
         }
@@ -379,7 +379,7 @@ public class LogManager extends McuManager {
          *
          * @return the next index.
          */
-        public int getNextIndex() {
+        public long getNextIndex() {
             return mNextIndex;
         }
 
@@ -388,7 +388,7 @@ public class LogManager extends McuManager {
          *
          * @param nextIndex the next index.
          */
-        public void setNextIndex(int nextIndex) {
+        public void setNextIndex(long nextIndex) {
             mNextIndex = nextIndex;
         }
 

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/log/McuMgrLogResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/log/McuMgrLogResponse.java
@@ -22,7 +22,7 @@ import io.runtime.mcumgr.util.CBOR;
 
 public class McuMgrLogResponse extends McuMgrResponse {
     @JsonProperty("next_index")
-    public int next_index;
+    public long next_index;
     @JsonProperty("logs")
     public LogResult[] logs;
 
@@ -93,7 +93,7 @@ public class McuMgrLogResponse extends McuMgrResponse {
          * Log entry index. The index should be unique to this entry.
          */
         @JsonProperty("index")
-        public int index;
+        public long index;
 
         /**
          * Module which logged the entry.


### PR DESCRIPTION
At a certain point, the device will log to an index which is not representable by an int.

This PR upgrades all the ints to longs 