### PR TITLE
Add imghash field to log show response

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/log/McuMgrLogResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/log/McuMgrLogResponse.java
@@ -108,6 +108,14 @@ public class McuMgrLogResponse extends McuMgrResponse {
         @JsonProperty("type")
         public String type;
 
+        /**
+         * The first 4 bytes of the build ID (image hash) which was running when this log entry was
+         * written by the device.
+         */
+        @Nullable
+        @JsonProperty("imghash")
+        public byte[] imghash;
+
         @JsonCreator
         public Entry() {}
 


### PR DESCRIPTION
This supports a recent feature which allows the device to include a truncated image hash of the image running when a log entry was written.

The change is backwards compatible with devices which may not include the image hash.

Firmware side commit: https://github.com/apache/mynewt-mcumgr/commit/542db228b5430e5bcca62b318cfd7902e9385a15