### PR TITLE
Deprecate next_index

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/response/log/McuMgrLogResponse.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/response/log/McuMgrLogResponse.java
@@ -21,14 +21,18 @@ import io.runtime.mcumgr.util.ByteUtil;
 import io.runtime.mcumgr.util.CBOR;
 
 public class McuMgrLogResponse extends McuMgrResponse {
+
+    @Deprecated
     @JsonProperty("next_index")
     public long next_index;
+
     @JsonProperty("logs")
     public LogResult[] logs;
 
     @JsonCreator
     public McuMgrLogResponse() {}
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class LogResult {
 
         public static final int LOG_TYPE_STREAM = 0;


### PR DESCRIPTION
`next_index` currently offers almost no value and is not used if using a per log index (rather than global).

The field will be removed in future releases.