### PR TITLE
Transfer deadlocks fixed

### DIFF
--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/FsManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/FsManager.java
@@ -212,13 +212,32 @@ public class FsManager extends TransferManager {
      * <p>
      * The upload may be controlled using the {@link TransferController} returned by this method.
      *
-     * @param callback  Receives callbacks from the upload.
+     * @param callback Receives callbacks from the upload.
      * @return The object used to control this upload.
      * @see TransferController
      */
     @NotNull
     public TransferController fileDownload(@NotNull String name, @NotNull DownloadCallback callback) {
         return startDownload(new FileDownload(name, callback));
+    }
+
+    /**
+     * Start image upload.
+     * <p>
+     * Multiple calls will queue multiple uploads, executed sequentially. This includes file
+     * downloads executed from {@link #fileUpload}.
+     * <p>
+     * The upload may be controlled using the {@link TransferController} returned by this method.
+     *
+     * @param callback Receives callbacks from the upload.
+     * @return The object used to control this upload.
+     * @see TransferController
+     * @deprecated Use {@link #fileDownload(String, DownloadCallback)} instead.
+     */
+    @Deprecated
+    @NotNull
+    public TransferController fileDownload(@NotNull String name, @NotNull byte[] data, @NotNull DownloadCallback callback) {
+        return fileDownload(name, callback);
     }
 
     /**

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/FsManager.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/managers/FsManager.java
@@ -57,7 +57,7 @@ public class FsManager extends TransferManager {
      * @param name   the file name.
      * @param offset the offset, from which the chunk will be requested.
      * @param callback the asynchronous callback.
-     * @see #fileDownload(String, byte[], DownloadCallback)
+     * @see #fileDownload(String, DownloadCallback)
      */
     public void download(@NotNull String name, int offset,
                          @NotNull McuMgrCallback<McuMgrFsDownloadResponse> callback) {
@@ -76,7 +76,7 @@ public class FsManager extends TransferManager {
      * @param name   the file name.
      * @param offset the offset, from which the chunk will be requested.
      * @return The upload response.
-     * @see #fileDownload(String, byte[], DownloadCallback)
+     * @see #fileDownload(String, DownloadCallback)
      */
     @NotNull
     public McuMgrFsDownloadResponse download(@NotNull String name, int offset)
@@ -212,13 +212,12 @@ public class FsManager extends TransferManager {
      * <p>
      * The upload may be controlled using the {@link TransferController} returned by this method.
      *
-     * @param data The file data to upload.
      * @param callback  Receives callbacks from the upload.
      * @return The object used to control this upload.
      * @see TransferController
      */
     @NotNull
-    public TransferController fileDownload(@NotNull String name, @NotNull byte[] data, @NotNull DownloadCallback callback) {
+    public TransferController fileDownload(@NotNull String name, @NotNull DownloadCallback callback) {
         return startDownload(new FileDownload(name, callback));
     }
 
@@ -266,7 +265,7 @@ public class FsManager extends TransferManager {
      *
      * @param name     the file name.
      * @param callback the file download callback.
-     * @deprecated Use {@link #fileDownload(String, byte[], DownloadCallback)} instead.
+     * @deprecated Use {@link #fileDownload(String, DownloadCallback)} instead.
      */
     @Deprecated
     public synchronized void download(@NotNull String name, @NotNull FileDownloadCallback callback) {

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Download.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Download.java
@@ -10,6 +10,7 @@ import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.response.DownloadResponse;
 import io.runtime.mcumgr.response.McuMgrResponse;
 
+@SuppressWarnings("unused")
 public abstract class Download extends Transfer {
 
     @Nullable
@@ -20,10 +21,16 @@ public abstract class Download extends Transfer {
     }
 
     protected Download(@Nullable DownloadCallback callback) {
-        super(null, 0);
         mCallback = callback;
     }
 
+    /**
+     * Sends read request from given offset.
+     *
+     * @param offset the offset.
+     * @return received response.
+     * @throws McuMgrException a reason of a failure.
+     */
     protected abstract DownloadResponse read(int offset) throws McuMgrException;
 
     @Override

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Transfer.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Transfer.java
@@ -5,42 +5,81 @@ import org.jetbrains.annotations.Nullable;
 import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.response.McuMgrResponse;
 
+@SuppressWarnings({"WeakerAccess", "unused"})
 public abstract class Transfer implements TransferCallback {
 
     @Nullable
     byte[] mData;
     int mOffset;
 
+    Transfer() {
+        mData = null;
+        mOffset = 0;
+    }
+
+    Transfer(int offset) {
+        mData = null;
+        mOffset = offset;
+    }
+
+    Transfer(@Nullable byte[] data) {
+        mData = data;
+        mOffset = 0;
+    }
+
     Transfer(@Nullable byte[] data, int offset) {
         mData = data;
         mOffset = offset;
     }
 
+    /**
+     * Resets the transfer status parameters.
+     */
     public abstract void reset();
 
+    /**
+     * Synchronously sends or requests the part of data from given offset.
+     *
+     * @param offset the offset, from which data will be transferred.
+     * @return the response received.
+     * @throws McuMgrException a reason of a failure.
+     */
     public abstract McuMgrResponse send(int offset) throws McuMgrException;
 
+    /**
+     * Synchronously sends or requests the next part of data.
+     *
+     * @return the response received.
+     * @throws McuMgrException a reason of a failure.
+     */
+    @SuppressWarnings("UnusedReturnValue")
     public McuMgrResponse sendNext() throws McuMgrException {
         return send(mOffset);
     }
 
+    /**
+     * Returns the data associated with this object. For incoming transfers the data are available
+     * only when the transfer is complete.
+     *
+     * @return the data.
+     */
     @Nullable
     public byte[] getData() {
         return mData;
     }
 
-    public void setData(@Nullable byte[] data) {
-        mData = data;
-    }
-
+    /**
+     * Returns the current offset.
+     *
+     * @return the offset.
+     */
     public int getOffset() {
         return mOffset;
     }
 
-    public void setOffset(int offset) {
-        mOffset = offset;
-    }
-
+    /**
+     * Returns true if transfer is complete.
+     */
     public boolean isFinished() {
         return mData != null && mOffset == mData.length;
     }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/TransferCallback.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/TransferCallback.java
@@ -13,7 +13,21 @@ public interface TransferCallback {
      * @param timestamp the timestamp of when the response was received.
      */
     void onProgressChanged(int current, int total, long timestamp);
+
+    /**
+     * Called when a response with failure has been received.
+     *
+     * @param e the exception.
+     */
     void onFailed(@NotNull McuMgrException e);
+
+    /**
+     * Called when the transfer is complete.
+     */
     void onCompleted();
+
+    /**
+     * Called when the transfer has been cancelled.
+     */
     void onCanceled();
 }

--- a/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Upload.java
+++ b/mcumgr-core/src/main/java/io/runtime/mcumgr/transfer/Upload.java
@@ -9,6 +9,7 @@ import io.runtime.mcumgr.exception.McuMgrException;
 import io.runtime.mcumgr.response.McuMgrResponse;
 import io.runtime.mcumgr.response.UploadResponse;
 
+@SuppressWarnings("unused")
 public abstract class Upload extends Transfer {
 
     private UploadCallback mCallback;
@@ -18,7 +19,7 @@ public abstract class Upload extends Transfer {
     }
 
     protected Upload(@NotNull byte[] data, @Nullable UploadCallback callback) {
-        super(data, 0);
+        super(data);
         mCallback = callback;
     }
 


### PR DESCRIPTION
This PR fixes upload, pausing, resuming and cancelling transfer using the new API.
The `mState` parameter was never modified, so the upload actually never worked. Also, pausing and resuming didn't change state. Canceling while transfer was paused was causing a deadlock.

Also, an unused parameter has been removed from `fileDownload` method.

New comments were added.

2 methods: `setData` and `setOffset` were removed, as they were dangerous and unnecessary. 