### PR TITLE
Migration to Android Studio 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A transport agnostic implementation of the McuManager protocol. Contains a defau
 ## Gradle Install
 
 #### McuManager BLE (Recommended)
-Contains the core and a BLE transport implementation using Nordic's [Android-BLE-Library v2](https://github.com/NordicSemiconductor/Android-BLE-Library/tree/develop). 
+Contains the core and a BLE transport implementation using Nordic's [Android-BLE-Library v2](https://github.com/NordicSemiconductor/Android-BLE-Library). 
 
 ```
 implementation 'io.runtime.mcumgr:mcumgr-ble:0.11.0'
@@ -39,7 +39,7 @@ McuManager are organized by functionality into command groups. In _mcumgr-androi
 
 Firmware upgrade is generally a four step process performed using commands from the `image` and `default` commands groups: `upload`, `test`, `reset`, and `confirm`.
 
-This library provides a `FirmwareUpgradeManager` as a convinience for upgrading the image running on a device. 
+This library provides a `FirmwareUpgradeManager` as a convenience for upgrading the image running on a device. 
 
 ### Example
 ```java

--- a/build.gradle
+++ b/build.gradle
@@ -10,11 +10,14 @@ buildscript {
     repositories {
         google()
         jcenter()
+        maven {
+            url "https://plugins.gradle.org/m2/"
+        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
+        classpath 'com.android.tools.build:gradle:4.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'com.dicedmelon.gradle:jacoco-android:0.1.4'
+        classpath 'com.hiya:jacoco-android:0.2'
     }
 }
 

--- a/gradle/jacoco-android.gradle
+++ b/gradle/jacoco-android.gradle
@@ -1,4 +1,4 @@
-apply plugin: 'jacoco-android'
+apply plugin: 'com.hiya.jacoco-android'
 
 jacoco {
     toolVersion = "0.8.5"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Mar 25 11:25:52 CET 2020
+#Tue Jun 09 13:34:11 CEST 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 29
-    buildToolsVersion "29.0.2"
+    buildToolsVersion "29.0.3"
 
     defaultConfig {
         applicationId "io.runtime.mcumgr"
@@ -37,11 +37,11 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.appcompat:appcompat:1.2.0-beta01'
+    implementation 'androidx.appcompat:appcompat:1.3.0-alpha01'
     implementation 'androidx.recyclerview:recyclerview:1.2.0-alpha03'
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta5'
-    implementation 'com.google.android.material:material:1.2.0-alpha06'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta6'
+    implementation 'com.google.android.material:material:1.3.0-alpha01'
 
     // Lifecycle extensions
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'


### PR DESCRIPTION
This PR migrates the project to Android Studio 4.
As Gradle in version 6.1.1. is now the min supported, also jacoco script had to be updated. Following https://github.com/arturdm/jacoco-android-gradle-plugin/issues/72 I migrated to a fork, that has Gradle issue fixed (see https://github.com/kiwix/kiwix-android/pull/1811#issuecomment-590887886). The original repo seems no longer be maintained.