### PR TITLE
#75 fixed

### DIFF
--- a/sample/src/main/java/io/runtime/mcumgr/sample/MainActivity.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/MainActivity.java
@@ -9,23 +9,27 @@ package io.runtime.mcumgr.sample;
 import android.bluetooth.BluetoothDevice;
 import android.os.Bundle;
 
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
+
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 
 import javax.inject.Inject;
 
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
-import androidx.fragment.app.Fragment;
 import dagger.android.AndroidInjector;
 import dagger.android.DispatchingAndroidInjector;
 import dagger.android.HasAndroidInjector;
-import io.runtime.mcumgr.McuMgrTransport;
 import io.runtime.mcumgr.sample.application.Dagger2Application;
 import io.runtime.mcumgr.sample.di.Injectable;
 import io.runtime.mcumgr.sample.fragment.DeviceFragment;
 import io.runtime.mcumgr.sample.fragment.FilesFragment;
 import io.runtime.mcumgr.sample.fragment.ImageFragment;
 import io.runtime.mcumgr.sample.fragment.LogsStatsFragment;
+import io.runtime.mcumgr.sample.viewmodel.MainViewModel;
+import io.runtime.mcumgr.sample.viewmodel.mcumgr.McuMgrViewModelFactory;
 
 @SuppressWarnings("ConstantConditions")
 public class MainActivity extends AppCompatActivity
@@ -35,7 +39,7 @@ public class MainActivity extends AppCompatActivity
     @Inject
     DispatchingAndroidInjector<Object> mDispatchingAndroidInjector;
     @Inject
-    McuMgrTransport mMcuMgrTransport;
+    McuMgrViewModelFactory mViewModelFactory;
 
     private Fragment mDeviceFragment;
     private Fragment mImageFragment;
@@ -48,7 +52,7 @@ public class MainActivity extends AppCompatActivity
     }
 
     @Override
-    protected void onCreate(final Bundle savedInstanceState) {
+    protected void onCreate(@Nullable final Bundle savedInstanceState) {
         // The target must be set before calling super.onCreate(Bundle).
         // Otherwise, Dagger2 will fail to inflate this Activity.
         final BluetoothDevice device = getIntent().getParcelableExtra(EXTRA_DEVICE);
@@ -58,6 +62,9 @@ public class MainActivity extends AppCompatActivity
 
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+
+        new ViewModelProvider(this, mViewModelFactory)
+                .get(MainViewModel.class);
 
         // Configure the view.
         final Toolbar toolbar = findViewById(R.id.toolbar);
@@ -118,16 +125,6 @@ public class MainActivity extends AppCompatActivity
             mImageFragment = getSupportFragmentManager().findFragmentByTag("image");
             mFilesFragment = getSupportFragmentManager().findFragmentByTag("fs");
             mLogsStatsFragment = getSupportFragmentManager().findFragmentByTag("logs");
-        }
-    }
-
-    @Override
-    protected void onDestroy() {
-        super.onDestroy();
-
-        if (isFinishing()) {
-            mMcuMgrTransport.release();
-            mMcuMgrTransport = null;
         }
     }
 }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/di/AppInjector.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/di/AppInjector.java
@@ -11,10 +11,14 @@ import android.app.Application;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.fragment.app.FragmentManager;
+
+import org.jetbrains.annotations.NotNull;
+
 import dagger.android.AndroidInjection;
 import dagger.android.HasAndroidInjector;
 import dagger.android.support.AndroidSupportInjection;
@@ -29,7 +33,7 @@ public class AppInjector {
     private AppInjector() {
     }
 
-    public static void init(final Dagger2Application application) {
+    public static void init(@NonNull final Dagger2Application application) {
         DaggerApplicationComponent.builder()
                 .contextModule(new ContextModule(application))
                 .build()
@@ -37,43 +41,45 @@ public class AppInjector {
 
         application.registerActivityLifecycleCallbacks(new Application.ActivityLifecycleCallbacks() {
             @Override
-            public void onActivityCreated(final Activity activity, final Bundle savedInstanceState) {
+            public void onActivityCreated(@NotNull final Activity activity,
+                                          @Nullable final Bundle savedInstanceState) {
                 handleActivity(activity);
             }
 
             @Override
-            public void onActivityStarted(final Activity activity) {
+            public void onActivityStarted(@NotNull final Activity activity) {
                 // empty
             }
 
             @Override
-            public void onActivityResumed(final Activity activity) {
+            public void onActivityResumed(@NotNull final Activity activity) {
                 // empty
             }
 
             @Override
-            public void onActivityPaused(final Activity activity) {
+            public void onActivityPaused(@NotNull final Activity activity) {
                 // empty
             }
 
             @Override
-            public void onActivityStopped(final Activity activity) {
+            public void onActivityStopped(@NotNull final Activity activity) {
                 // empty
             }
 
             @Override
-            public void onActivitySaveInstanceState(final Activity activity, final Bundle outState) {
+            public void onActivitySaveInstanceState(@NotNull final Activity activity,
+                                                    @NotNull final Bundle outState) {
                 // empty
             }
 
             @Override
-            public void onActivityDestroyed(final Activity activity) {
+            public void onActivityDestroyed(@NotNull final Activity activity) {
                 // empty
             }
         });
     }
 
-    private static void handleActivity(final Activity activity) {
+    private static void handleActivity(@NonNull final Activity activity) {
         if (activity instanceof Injectable || activity instanceof HasAndroidInjector) {
             AndroidInjection.inject(activity);
         }

--- a/sample/src/main/java/io/runtime/mcumgr/sample/di/component/McuMgrViewModelSubComponent.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/di/component/McuMgrViewModelSubComponent.java
@@ -7,6 +7,7 @@
 package io.runtime.mcumgr.sample.di.component;
 
 import dagger.Subcomponent;
+import io.runtime.mcumgr.sample.viewmodel.MainViewModel;
 import io.runtime.mcumgr.sample.viewmodel.mcumgr.DeviceStatusViewModel;
 import io.runtime.mcumgr.sample.viewmodel.mcumgr.EchoViewModel;
 import io.runtime.mcumgr.sample.viewmodel.mcumgr.FilesDownloadViewModel;
@@ -30,6 +31,8 @@ public interface McuMgrViewModelSubComponent {
     interface Builder {
         McuMgrViewModelSubComponent build();
     }
+
+    MainViewModel mainViewModel();
 
     DeviceStatusViewModel deviceStatusViewModel();
     EchoViewModel echoViewModel();

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/MainViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/MainViewModel.java
@@ -1,0 +1,27 @@
+package io.runtime.mcumgr.sample.viewmodel;
+
+import android.app.Application;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.AndroidViewModel;
+
+import javax.inject.Inject;
+
+import io.runtime.mcumgr.McuMgrTransport;
+
+public class MainViewModel extends AndroidViewModel {
+    @Inject
+    McuMgrTransport mMcuMgrTransport;
+
+    @Inject
+    public MainViewModel(@NonNull final Application application) {
+        super(application);
+    }
+
+    @Override
+    protected void onCleared() {
+        super.onCleared();
+
+        mMcuMgrTransport.release();
+    }
+}

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/ScannerViewModel.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/ScannerViewModel.java
@@ -19,7 +19,11 @@ import java.util.List;
 
 import javax.inject.Inject;
 
+import androidx.annotation.NonNull;
 import androidx.lifecycle.AndroidViewModel;
+
+import org.jetbrains.annotations.NotNull;
+
 import io.runtime.mcumgr.sample.utils.FilterUtils;
 import io.runtime.mcumgr.sample.utils.Utils;
 import no.nordicsemi.android.support.v18.scanner.BluetoothLeScannerCompat;
@@ -47,15 +51,18 @@ public class ScannerViewModel extends AndroidViewModel {
     }
 
     @Inject
-    public ScannerViewModel(final Application application, final SharedPreferences preferences) {
+    public ScannerViewModel(@NonNull final Application application,
+                            @NonNull final SharedPreferences preferences) {
         super(application);
         mPreferences = preferences;
 
         final boolean filterUuidRequired = isUuidFilterEnabled();
         final boolean filerNearbyOnly = isNearbyFilterEnabled();
 
-        mScannerStateLiveData = new ScannerStateLiveData(Utils.isBleEnabled(),
-                Utils.isLocationEnabled(application));
+        mScannerStateLiveData = new ScannerStateLiveData(
+                Utils.isBleEnabled(),
+                Utils.isLocationEnabled(application)
+        );
         mDevicesLiveData = new DevicesLiveData(filterUuidRequired, filerNearbyOnly);
         registerBroadcastReceivers(application);
     }
@@ -150,7 +157,7 @@ public class ScannerViewModel extends AndroidViewModel {
 
     private final ScanCallback scanCallback = new ScanCallback() {
         @Override
-        public void onScanResult(final int callbackType, final ScanResult result) {
+        public void onScanResult(final int callbackType, @NotNull final ScanResult result) {
             // This callback will be called only if the scan report delay is not set or is set to 0.
 
             // If the packet has been obtained while Location was disabled, mark Location as not required
@@ -164,7 +171,7 @@ public class ScannerViewModel extends AndroidViewModel {
         }
 
         @Override
-        public void onBatchScanResults(final List<ScanResult> results) {
+        public void onBatchScanResults(@NotNull final List<ScanResult> results) {
             // This callback will be called only if the report delay set above is greater then 0.
 
             // If the packet has been obtained while Location was disabled, mark Location as not required
@@ -193,7 +200,7 @@ public class ScannerViewModel extends AndroidViewModel {
     /**
      * Register for required broadcast receivers.
      */
-    private void registerBroadcastReceivers(final Application application) {
+    private void registerBroadcastReceivers(@NonNull final Application application) {
         application.registerReceiver(mBluetoothStateBroadcastReceiver, new IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED));
         if (Utils.isMarshmallowOrAbove()) {
             application.registerReceiver(mLocationProviderChangedReceiver, new IntentFilter(LocationManager.MODE_CHANGED_ACTION));
@@ -255,7 +262,7 @@ public class ScannerViewModel extends AndroidViewModel {
      * @return true, if the device may be dismissed, false otherwise.
      */
     @SuppressWarnings({"BooleanMethodIsAlwaysInverted", "RedundantIfStatement"})
-    private boolean isNoise(final ScanResult result) {
+    private boolean isNoise(@NonNull final ScanResult result) {
         // Do not show non-connectable devices.
         // Only Android Oreo or newer can say if a device is connectable. On older Android versions
         // the Support Scanner Library assumes all devices are connectable (compatibility mode).

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/ViewModelFactory.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/ViewModelFactory.java
@@ -20,7 +20,7 @@ import androidx.lifecycle.ViewModelProvider;
 import io.runtime.mcumgr.sample.di.component.ViewModelSubComponent;
 
 public class ViewModelFactory extends ViewModelProvider.AndroidViewModelFactory {
-    private final Map<Class, Callable<? extends ViewModel>> creators;
+    private final Map<Class<? extends ViewModel>, Callable<? extends ViewModel>> creators;
 
     /**
      * Creates a {@code AndroidViewModelFactory}.
@@ -44,7 +44,7 @@ public class ViewModelFactory extends ViewModelProvider.AndroidViewModelFactory 
     public <T extends ViewModel> T create(@NonNull final Class<T> modelClass) {
         Callable<? extends ViewModel> creator = creators.get(modelClass);
         if (creator == null) {
-            for (Map.Entry<Class, Callable<? extends ViewModel>> entry : creators.entrySet()) {
+            for (Map.Entry<Class<? extends ViewModel>, Callable<? extends ViewModel>> entry : creators.entrySet()) {
                 if (modelClass.isAssignableFrom(entry.getKey())) {
                     creator = entry.getValue();
                     break;

--- a/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/McuMgrViewModelFactory.java
+++ b/sample/src/main/java/io/runtime/mcumgr/sample/viewmodel/mcumgr/McuMgrViewModelFactory.java
@@ -16,15 +16,17 @@ import androidx.annotation.NonNull;
 import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.ViewModelProvider;
 import io.runtime.mcumgr.sample.di.component.McuMgrViewModelSubComponent;
+import io.runtime.mcumgr.sample.viewmodel.MainViewModel;
 
 public class McuMgrViewModelFactory implements ViewModelProvider.Factory {
-    private final Map<Class, Callable<? extends ViewModel>> creators;
+    private final Map<Class<? extends ViewModel>, Callable<? extends ViewModel>> creators;
 
     @Inject
     public McuMgrViewModelFactory(@NonNull final McuMgrViewModelSubComponent viewModelSubComponent) {
         creators = new HashMap<>();
         // we cannot inject view models directly because they won't be bound to the owner's
         // view model scope.
+        creators.put(MainViewModel.class, viewModelSubComponent::mainViewModel);
         creators.put(DeviceStatusViewModel.class, viewModelSubComponent::deviceStatusViewModel);
         creators.put(EchoViewModel.class, viewModelSubComponent::echoViewModel);
         creators.put(ResetViewModel.class, viewModelSubComponent::resetViewModel);
@@ -43,7 +45,7 @@ public class McuMgrViewModelFactory implements ViewModelProvider.Factory {
     public <T extends ViewModel> T create(@NonNull final Class<T> modelClass) {
         Callable<? extends ViewModel> creator = creators.get(modelClass);
         if (creator == null) {
-            for (Map.Entry<Class, Callable<? extends ViewModel>> entry : creators.entrySet()) {
+            for (Map.Entry<Class<? extends ViewModel>, Callable<? extends ViewModel>> entry : creators.entrySet()) {
                 if (modelClass.isAssignableFrom(entry.getKey())) {
                     creator = entry.getValue();
                     break;


### PR DESCRIPTION
This PR fixed #75.
The `McuMgrTransport` instance is now kept in the view model, not in the activity itself, which makes it "live" until user goes back to scanner activity, and the view manager is cleared.