### PR TITLE
BLE Library updated to 2.2.1

### DIFF
--- a/mcumgr-ble/build.gradle
+++ b/mcumgr-ble/build.gradle
@@ -20,7 +20,7 @@ android {
 
 dependencies {
     // Import the BLE Library
-    api 'no.nordicsemi.android:ble:2.2.0'
+    api 'no.nordicsemi.android:ble:2.2.1'
 
     // Logging
     implementation 'org.slf4j:slf4j-api:1.7.30'


### PR DESCRIPTION
This PR increments version of BLE Library:
https://github.com/NordicSemiconductor/Android-BLE-Library/releases/tag/v2.2.1