### PR TITLE
Dependencies updated

### DIFF
--- a/mcumgr-ble/build.gradle
+++ b/mcumgr-ble/build.gradle
@@ -20,7 +20,7 @@ android {
 
 dependencies {
     // Import the BLE Library
-    api 'no.nordicsemi.android:ble:2.2.1'
+    api 'no.nordicsemi.android:ble:2.2.2'
 
     // Logging
     implementation 'org.slf4j:slf4j-api:1.7.30'

--- a/mcumgr-ble/build.gradle
+++ b/mcumgr-ble/build.gradle
@@ -20,7 +20,7 @@ android {
 
 dependencies {
     // Import the BLE Library
-    api 'no.nordicsemi.android:ble:2.2.2'
+    api 'no.nordicsemi.android:ble:2.2.3'
 
     // Logging
     implementation 'org.slf4j:slf4j-api:1.7.30'

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -38,9 +38,9 @@ android {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.3.0-alpha01'
-    implementation 'androidx.recyclerview:recyclerview:1.2.0-alpha03'
+    implementation 'androidx.recyclerview:recyclerview:1.2.0-alpha04'
     implementation 'androidx.cardview:cardview:1.0.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta6'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta7'
     implementation 'com.google.android.material:material:1.3.0-alpha01'
 
     // Lifecycle extensions


### PR DESCRIPTION
There was a bug in BLE Library 2.2.1. This PR changes dependency to version 2.2.3.
Additionally, to other dependencies were updated.
Btw, shouldn't they use release versions, not alpha? On the other hand it doesn't really matter :)