### PR TITLE
Add deprecation notice to project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# DEPRECATED
+
+This repository is deprecated and no longer maintained, please use the following forks:
+
+- Android: [NordicSemiconductor/Android-nRF-Connect-Device-Manager](https://github.com/NordicSemiconductor/Android-nRF-Connect-Device-Manager)
+- iOS: [NordicSemiconductor/IOS-nRF-Connect-Device-Manager](https://github.com/NordicSemiconductor/IOS-nRF-Connect-Device-Manager)
+
+---
+
 [![codecov](https://codecov.io/gh/JuulLabs-OSS/mcumgr-android/branch/master/graph/badge.svg)](https://codecov.io/gh/JuulLabs-OSS/mcumgr-android)
 
 # McuManager Android


### PR DESCRIPTION
As discussed in https://github.com/JuulLabs-OSS/mcumgr-android/pull/79#issuecomment-906730649, the `mcumgr-android` project is no longer maintained under the JuulLabs-OSS org.